### PR TITLE
[1.6.2] Fixed JDK 17 certificates issue on the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM openjdk:8u332-jdk
 
 COPY --from=java17 /usr/java/openjdk-17 /usr/java/openjdk-17
 
+# For some reason the jdk17 image does not come with any certificates, which causes problems
 RUN cp --remove-destination /usr/local/openjdk-8/jre/lib/security/cacerts /usr/java/openjdk-17/lib/security/cacerts
 
 COPY . /headlessmc

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@
 
 # TODO: download HMC-Specifics?
 FROM openjdk:17.0.2-jdk as java17
-
 FROM openjdk:8u332-jdk
 
 COPY --from=java17 /usr/java/openjdk-17 /usr/java/openjdk-17
+
+RUN cp --remove-destination /usr/local/openjdk-8/jre/lib/security/cacerts /usr/java/openjdk-17/lib/security/cacerts
 
 COPY . /headlessmc
 WORKDIR /headlessmc

--- a/headlessmc-launcher/build.gradle
+++ b/headlessmc-launcher/build.gradle
@@ -7,7 +7,7 @@ application {
     mainClass = MAIN_CLASS
 }
 
-version = '1.6.1'
+version = '1.6.2'
 
 run {
     standardInput = System.in

--- a/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/Launcher.java
+++ b/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/Launcher.java
@@ -15,7 +15,7 @@ import me.earth.headlessmc.launcher.version.VersionService;
 @Getter
 @RequiredArgsConstructor
 public class Launcher implements HeadlessMc {
-    public static final String VERSION = "1.6.1";
+    public static final String VERSION = "1.6.2";
 
     @Delegate
     private final HeadlessMc headlessMc;

--- a/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/command/FabricCommandTest.java
+++ b/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/command/FabricCommandTest.java
@@ -10,6 +10,7 @@ import me.earth.headlessmc.launcher.version.ParsesVersions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,7 +37,7 @@ public class FabricCommandTest implements UsesResources, ParsesVersions {
         val java = new Java("dummyJava", 17);
         val jar = new File("dummyJar");
 
-        val result = command.getCommand(version, java, jar);
+        val result = command.getCommand(version, java, jar, new ArrayList<>());
         assertEquals(Arrays.asList(
             "dummyJava", "-jar", jar.getAbsolutePath(), "client",
             "-noprofile", "-mcversion", "1.19"), result);

--- a/headlessmc-scripts/hmc
+++ b/headlessmc-scripts/hmc
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-java -jar headlessmc-launcher-1.6.1.jar --command $@
+java -jar headlessmc-launcher-1.6.2.jar --command $@

--- a/headlessmc-scripts/hmc.bat
+++ b/headlessmc-scripts/hmc.bat
@@ -1,2 +1,2 @@
 @echo off
-"%JAVA_HOME%\bin\java" -jar headlessmc-launcher-1.6.1.jar --command %*
+"%JAVA_HOME%\bin\java" -jar headlessmc-launcher-1.6.2.jar --command %*

--- a/headlessmc-scripts/hmw
+++ b/headlessmc-scripts/hmw
@@ -1,3 +1,3 @@
 #!/bin/bash
 # when running in docker on windows bash seems to be at /bin/bash TODO: can we make this one script?
-java -jar headlessmc-launcher-1.6.1.jar --command $@
+java -jar headlessmc-launcher-1.6.2.jar --command $@


### PR DESCRIPTION
`hmc download 1.19.3` then `hmc fabric 1.19.3`
causes
```
Caused by: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty
        at java.base/java.security.cert.PKIXParameters.setTrustAnchors(PKIXParameters.java:200)
```
Reason being that the jdk 17 image did not come with any SSL certificates