### PR TITLE
Fix parseVersion to make it compatible with Termux

### DIFF
--- a/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/java/JavaVersionParser.java
+++ b/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/java/JavaVersionParser.java
@@ -9,8 +9,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class JavaVersionParser {
+
     private static final Pattern PATTERN = Pattern.compile(
-        "version \"([0-9]+\\.[0-9]+\\.[0-9_]+(?:\\.[0-9]+)*)\"");
+        "version \"(\\d+)[.-](\\d*)");
 
     public int parseVersionCommand(String path) throws IOException {
         Process prcs = new ProcessBuilder().command(path, "-version").start();
@@ -26,8 +27,10 @@ public class JavaVersionParser {
         if (!matcher.find()) {
             throw new IOException("Couldn't parse '" + output + "'");
         }
-
-        return Integer.parseInt(getMajorVersion(matcher.group(1)));
+        if (matcher.group(1).equals("1")) {
+            return Integer.parseInt(matcher.group(2));
+        }
+        return Integer.parseInt(matcher.group(1));
     }
 
     public static String getMajorVersion(String versionString) {

--- a/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/java/JavaVersionParserTest.java
+++ b/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/java/JavaVersionParserTest.java
@@ -29,6 +29,14 @@ public class JavaVersionParserTest {
                 "Java HotSpot(TM) 64-Bit Server VM (build 25.331-b09," +
                 " mixed mode)");
         Assertions.assertEquals(8, version);
+
+        version = parser.parseVersion(
+            "java version \"17-internal\" 2021-09-14\nOpenJDK" +
+                " Runtime Environment (build 17-internal+0-adhoc..src)\n" +
+                "OpenJDK 64-Bit Server VM (build 17-" +
+                "internal+0-adhoc..src)");
+        Assertions.assertEquals(17, version);
+
         Assertions.assertThrows(IOException.class,
                                 () -> parser.parseVersion("test"));
     }


### PR DESCRIPTION
I don't know if it will break anything. But so far it works well on my Termux with openjdk-17 and opengl installed.

### My setup:
1. Install Termux
2. Open Termux
3. Run `pkg upgrade`, then `apt-get upgrade`
4. Run `pkg install openjdk-17`, `pkg install opengl`
5. Download Termux release to my phone and put it in a new folder named hmc
6. Run `termux-setup-storage`
7. Go to hmc directory, something like `cd $HOME/storage/shared/hmc`
8. Run `java -jar <hmc release name>.jar`
9. Install a Minecraft and it's fabric version `download <version>`, `fabric <version>`
10. Launch fabric version: `versions`, `launch <version name> -command -lwjgl`
11. `quit`
12. Download HMC-Specific mod to the fabric version
13. Put the mod in $HOME/.minecraft/mods using `cp` command
14. Re-run and launch the fabric version
15. `connect <server address>`
16. Done