### PR TITLE
Update shadow plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import io.franzbecker.gradle.lombok.task.DelombokTask
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.0'
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
 }
 
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
-    apply plugin: 'com.github.johnrengelman.shadow'
+    apply plugin: 'com.gradleup.shadow'
 
     // no lombok for that project, cause its doing naughty things with stubing java.lang classes
     if (project != project(':headlessmc-modlauncher')) {


### PR DESCRIPTION
Just updates the shadow plugin to the latest.

The repo was moved to [https://github.com/GradleUp/shadow](https://github.com/GradleUp/shadow)

I tried to attempt to switch to [https://plugins.gradle.org/plugin/io.freefair.lombok](https://plugins.gradle.org/plugin/io.freefair.lombok) for the lombok plugin but I kind of gave up as I don't understand how to fix your delombok task lol.