### PR TITLE
Added CrashReportWatcher for testing purposes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-project_version=2.5.1
+project_version=2.6.0
 org.gradle.jvmargs=-Xmx2048m
 # set to true if you want to run the headlessmc-launcher-wrapper integration tests
 hmc_integration_test_enabled=false

--- a/headlessmc-api/src/main/java/me/earth/headlessmc/api/HeadlessMcApi.java
+++ b/headlessmc-api/src/main/java/me/earth/headlessmc/api/HeadlessMcApi.java
@@ -25,7 +25,7 @@ public class HeadlessMcApi {
     /**
      * The current version of HeadlessMc.
      */
-    public static final String VERSION = "2.5.1";
+    public static final String VERSION = "2.6.0";
     /**
      * The string "HeadlessMC".
      */

--- a/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/LauncherProperties.java
+++ b/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/LauncherProperties.java
@@ -104,4 +104,6 @@ public interface LauncherProperties extends HmcProperties {
     Property<String> JAVA_DISTRIBUTION = string("hmc.auto.java.distribution");
     Property<Boolean> JAVA_ALWAYS_ADD_FILE_PERMISSIONS = bool("hmc.java.always.add.file.permissions");
 
+    Property<Boolean> CRASH_REPORT_WATCHER = bool("hmc.crash.report.watcher");
+
 }

--- a/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/test/CrashReportWatcher.java
+++ b/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/test/CrashReportWatcher.java
@@ -45,7 +45,7 @@ public class CrashReportWatcher implements AutoCloseable {
                     }
 
                     for (WatchEvent<?> event : key.pollEvents()) {
-                        if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                        if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())) {
                             Path path = (Path) event.context();
                             for (Consumer<Path> listener : listeners) {
                                 listener.accept(path);

--- a/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/test/CrashReportWatcher.java
+++ b/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/test/CrashReportWatcher.java
@@ -55,7 +55,9 @@ public class CrashReportWatcher implements AutoCloseable {
 
                     key.reset();
                 }
-            } catch (IOException e) {
+            } catch (ClosedWatchServiceException ignored) {
+                log.debug("WatchService closed");
+            } catch (Exception e) {
                 log.error("CrashReport Watcher encountered Exception", e);
             }
         });

--- a/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/test/CrashReportWatcher.java
+++ b/headlessmc-launcher/src/main/java/me/earth/headlessmc/launcher/test/CrashReportWatcher.java
@@ -1,0 +1,101 @@
+package me.earth.headlessmc.launcher.test;
+
+import lombok.CustomLog;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+@CustomLog
+public class CrashReportWatcher implements AutoCloseable {
+    private final CopyOnWriteArrayList<Consumer<Path>> listeners = new CopyOnWriteArrayList<>();
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    private final WatchService watchService;
+    private final ExecutorService executor;
+    private final boolean shutDownExecutorService;
+
+    public CrashReportWatcher(Path directory,
+                              ExecutorService executorService,
+                              boolean shutDownExecutorService) throws IOException {
+        this.watchService = FileSystems.getDefault().newWatchService();
+        this.executor = executorService;
+        this.shutDownExecutorService = shutDownExecutorService;
+        directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+        executorService.submit(() -> {
+            synchronized (started) {
+                started.set(true);
+                started.notifyAll();
+            }
+
+            try {
+                while (!closed.get()) {
+                    WatchKey key;
+                    try {
+                        key = watchService.take();
+                    } catch (InterruptedException e) {
+                        log.info("CrashReport Watcher interrupted");
+                        watchService.close();
+                        return;
+                    }
+
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                            Path path = (Path) event.context();
+                            for (Consumer<Path> listener : listeners) {
+                                listener.accept(path);
+                            }
+                        }
+                    }
+
+                    key.reset();
+                }
+            } catch (IOException e) {
+                log.error("CrashReport Watcher encountered Exception", e);
+            }
+        });
+    }
+
+    public void addListener(Consumer<Path> listener) {
+        listeners.add(listener);
+    }
+
+    public void waitForStart() throws InterruptedException {
+        synchronized (started) {
+            if (!started.get()) {
+                started.wait();
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed.set(true);
+        watchService.close();
+        if (shutDownExecutorService) {
+            executor.shutdown();
+        }
+    }
+
+    public static CrashReportWatcher forGameDir(Path gameDir) throws IOException {
+        Path crashReportsDir = gameDir.resolve("crash-reports");
+        if (!Files.exists(crashReportsDir)) {
+            Files.createDirectories(crashReportsDir);
+        }
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor(r -> {
+            Thread thread = new Thread(r);
+            thread.setDaemon(true);
+            thread.setName("CrashReportWatcher");
+            return thread;
+        });
+
+        return new CrashReportWatcher(crashReportsDir, executorService, true);
+    }
+
+}

--- a/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/LauncherMock.java
+++ b/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/LauncherMock.java
@@ -1,5 +1,6 @@
 package me.earth.headlessmc.launcher;
 
+import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 import lombok.val;
 import me.earth.headlessmc.api.HeadlessMcImpl;
@@ -26,6 +27,8 @@ import me.earth.headlessmc.logging.LoggingService;
 import me.earth.headlessmc.os.OS;
 import net.raphimc.minecraftauth.step.java.session.StepFullJavaSession;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,8 +40,10 @@ public class LauncherMock {
         INSTANCE = create();
     }
 
+    @SneakyThrows
     public static Launcher create() {
-        val base = FileManager.forPath("build");
+        Path tempDir = Files.createTempDirectory("hmc-launcher-test");
+        val base = FileManager.forPath(tempDir.toAbsolutePath().toString());
         val fileManager = base.createRelative("fileManager");
         val configs = new ConfigService(fileManager);
         configs.refresh();

--- a/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/download/DownloadServiceTest.java
+++ b/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/download/DownloadServiceTest.java
@@ -1,6 +1,7 @@
 package me.earth.headlessmc.launcher.download;
 
 import me.earth.headlessmc.jline.JlineProgressbarProvider;
+import me.earth.headlessmc.launcher.LauncherMock;
 import net.lenni0451.commons.httpclient.HttpResponse;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ public class DownloadServiceTest {
         };
 
         DownloadService finalDownloadService = downloadService;
-        assertThrows(IOException.class, () -> finalDownloadService.download("http://example.com", Paths.get("build").resolve("test")));
+        assertThrows(IOException.class, () -> finalDownloadService.download("http://example.com", LauncherMock.INSTANCE.getFileManager().getBase().toPath().resolve("test")));
         byte[] bytes = { 1, 2, 3, 4};
         downloadService = new DownloadService() {
             @Override
@@ -34,7 +35,7 @@ public class DownloadServiceTest {
 
         String sha1 = "12dada1fff4d4787ade3333147202c3b443e376f";
         assertEquals(sha1, downloadService.getChecksumService().hash(bytes));
-        assertThrows(IOException.class, () -> finalDownloadService.download("http://example.com", Paths.get("build").resolve("test"), null, "wronghash"));
+        assertThrows(IOException.class, () -> finalDownloadService.download("http://example.com", LauncherMock.INSTANCE.getFileManager().getBase().toPath().resolve("test"), null, "wronghash"));
         assertSame(bytes, downloadService.download(new URL("http://example.com"), null, sha1));
         assertSame(bytes, downloadService.download(new URL("http://example.com"), null, null));
         assertSame(bytes, downloadService.download(new URL("http://example.com"), 4L, null));

--- a/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/test/CrashReportWatcherTest.java
+++ b/headlessmc-launcher/src/test/java/me/earth/headlessmc/launcher/test/CrashReportWatcherTest.java
@@ -1,0 +1,36 @@
+package me.earth.headlessmc.launcher.test;
+
+import me.earth.headlessmc.launcher.LauncherMock;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CrashReportWatcherTest {
+    @Test
+    public void testCrashReportWatcher() throws IOException, InterruptedException {
+        Path path = LauncherMock.INSTANCE.getMcFiles().getBase().toPath();
+        try (CrashReportWatcher crashReportWatcher = CrashReportWatcher.forGameDir(path)) {
+            Path crashReportsDir = path.resolve("crash-reports");
+            AtomicReference<Path> pathRef = new AtomicReference<>();
+            crashReportWatcher.addListener(p -> {
+                synchronized (pathRef) {
+                    pathRef.set(p);
+                    pathRef.notifyAll();
+                }
+            });
+
+            synchronized (pathRef) {
+                Files.createFile(crashReportsDir.resolve("test.txt"));
+                pathRef.wait(60_000);
+            }
+
+            assertEquals("test.txt", pathRef.get().getFileName().toString());
+        }
+    }
+
+}

--- a/headlessmc-scripts/hmc
+++ b/headlessmc-scripts/hmc
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-java -jar headlessmc-launcher-wrapper-2.5.1.jar --command $@
+java -jar headlessmc-launcher-wrapper-2.6.0.jar --command $@

--- a/headlessmc-scripts/hmc.bat
+++ b/headlessmc-scripts/hmc.bat
@@ -1,2 +1,2 @@
 @echo off
-"%JAVA_HOME%\bin\java" -jar headlessmc-launcher-wrapper-2.5.1.jar --command %*
+"%JAVA_HOME%\bin\java" -jar headlessmc-launcher-wrapper-2.6.0.jar --command %*

--- a/headlessmc-scripts/hmw
+++ b/headlessmc-scripts/hmw
@@ -1,3 +1,3 @@
 #!/bin/bash
 # when running in docker on windows bash seems to be at /bin/bash TODO: can we make this one script?
-java -jar headlessmc-launcher-wrapper-2.5.1.jar --command $@
+java -jar headlessmc-launcher-wrapper-2.6.0.jar --command $@


### PR DESCRIPTION
Kills the process if a crash-report gets created. Modloaders like Neoforge like to display an error screen and wait indefinitely while the game has crashed, which is not good for testing purposes, e.g. in the CI.

Related: https://github.com/headlesshq/mc-runtime-test/issues/60

Closes #219 